### PR TITLE
Bump cereal version

### DIFF
--- a/hfsevents.cabal
+++ b/hfsevents.cabal
@@ -28,7 +28,7 @@ library
   build-depends:
     base >= 4 && < 5,
     bytestring,
-    cereal >= 0.3 && < 0.4,
+    cereal >= 0.3 && < 0.5,
     unix,
     mtl,
     text


### PR DESCRIPTION
Seems to work fine with me with `cereal-0.4.0.1`.
